### PR TITLE
Update reference to prescient.el in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -73,6 +73,6 @@ Helm and configure Icomplete to use it as follows:
 Helm UI in =helm-mode= rather than using Icomplete.)
 
 The combination of [[https://github.com/raxod502/selectrum][Selectrum]] and [[https://github.com/raxod502/prescient.el][prescient.el]] also provides matching
-of space-separated components in any order, but the components are
-matched as either literal strings or initialisms rather than as
-regexps.
+of space-separated components in any order, but each component can be
+matched not only as a regexp, but also a literal string or an
+initialism, so the set of candidates returned may be larger.


### PR DESCRIPTION
In fact, the way `prescient.el` works by default (see `prescient-filter-method`) is that each component can match as _either_ a regexp, literal string, or initialism. But this is configurable, so you could easily set it to only match the components as regexps.