### PR TITLE
Add orderless-strict-initialism style

### DIFF
--- a/README.org
+++ b/README.org
@@ -101,6 +101,22 @@ define new matching styles. The predefined ones are:
 
   This maps =abc= to =\<a.*\<b.*\c=.
 
+- orderless-strict-initialism :: like initialism but only allow
+  non-letters in between the matched words.
+
+	For example =fb= would match =foo-bar= but not =foo-qux-bar=.
+
+- orderless-strict-leading-initialism :: like strict-initialism but
+  require the first initial to match the candidate's first word.
+
+	For example =bb= would match =bar-baz= but not =foo-bar-baz=.
+
+- orderless-strict-full-initialism :: like strict-initialism but
+  require the first initial to match the candidate's first word and the
+  last initial to be at the final word.
+
+	For example =fbb= would match =foo-bar-baz= but not =foo-bar-baz-qux=.
+
 - orderless-flex :: the characters of the component should appear in
   that order in the candidate, but not necessarily consecutively.
 


### PR DESCRIPTION
This style does not allow unmatched words comprised of letters to be in between initials.

I don't think the word-end is strictly necessary, but I thought it made the intention more explicit.

As a side note, I want to say how awesome this package is. It's great to have this matching everywhere including for incsearch (with `swiper-isearch` at least) and for completion (manual at least, if only company could easily integrate). It's incredibly fast, and the highlight colors look incredible. I've also stolen these colors for git gutter. I was kind of lukewarm about it at first, but you have converted me completely. Now if only I can get this kind of filtering everywhere outside of Emacs. Fzf is a good approximation for terminal completion (though without real initialism). Browser completion is meh for the most part. Anyway, keep up the great work!

Wait WHAT. This works with company!? I guess company supports completion-styles? That's incredible!!!! You should mention that in the readme. It doesn't show highlights in the completion popup though. I assume that's something I should open an issue on the company repo for?