### PR TITLE
Remove pattern compiler variable

### DIFF
--- a/README.org
+++ b/README.org
@@ -237,15 +237,12 @@ completion is the one that ends up being used, of course.
 
 ** Pattern compiler
 
-The default mechanism for turning an input string into a list of
-regexps to match against, configured using =orderless-matching-styles=,
-is probably flexible enough for the vast majority of users. But if you
-want to completely change the mechanism, customize the
-=orderless-pattern-compiler=. It's value should be a function from
-string to lists of regexps. You might find it convenient to use
-=orderless-default-pattern-compiler= as a subroutine in your own pattern
-compiler, it conveniently accepts optional arguments that specify
-lists to use instead of =orderless-matching-styles=.
+The default mechanism for turning an input string into a list of regexps to
+match against, configured using =orderless-matching-styles=, is probably
+flexible enough for the vast majority of users. The patterns are compiled by the
+=orderless-pattern-compiler=. Under special circumstances it may be useful to
+implement a custom pattern compiler by advising the
+=orderless-pattern-compiler=.
 
 ** Interactively changing the configuration
 

--- a/orderless.el
+++ b/orderless.el
@@ -152,23 +152,8 @@ match as literals.  As another example, a style dispatcher could
 arrange for a component starting with `?' to match the rest of
 the component in the `orderless-flex' style.  For more
 information on how this variable is used, see
-`orderless-default-pattern-compiler'."
+`orderless-pattern-compiler'."
   :type 'hook)
-
-(defcustom orderless-pattern-compiler #'orderless-default-pattern-compiler
-  "The `orderless' pattern compiler.
-This should be a function that takes an input pattern and returns
-a list of regexps that must all match a candidate in order for
-the candidate to be considered a completion of the pattern.
-
-The default pattern compiler is probably flexible enough for most
-users.  See `orderless-default-pattern-compiler' for details.
-
-The documentation for `orderless-matching-styles' is written
-assuming the default pattern compiler is used, if you change the
-pattern compiler it can, of course, do anything and need not
-consult this variable at all."
-  :type 'function)
 
 (defcustom orderless-smart-case t
   "Whether to use smart case.
@@ -306,7 +291,7 @@ For the user's convenience, if REGEXPS is a string, it is
 converted to a list of regexps according to the value of
 `orderless-matching-styles'."
     (when (stringp regexps)
-      (setq regexps (funcall orderless-pattern-compiler regexps)))
+      (setq regexps (orderless-pattern-compiler regexps)))
     (cl-loop for original in strings
              for string = (copy-sequence original)
              collect (orderless--highlight regexps string)))
@@ -362,7 +347,7 @@ DEFAULT as the list of styles."
            when result return (cons result string)
            finally (return (cons default string))))
 
-(defun orderless-default-pattern-compiler (pattern &optional styles dispatchers)
+(defun orderless-pattern-compiler (pattern &optional styles dispatchers)
   "Build regexps to match the components of PATTERN.
 Split PATTERN on `orderless-component-separator' and compute
 matching styles for each component.  For each component the style
@@ -376,11 +361,7 @@ dispatchers.
 The STYLES default to `orderless-matching-styles', and the
 DISPATCHERS default to `orderless-dipatchers'.  Since nil gets you
 the default, if want to no dispatchers to be run, use '(ignore)
-as the value of DISPATCHERS.
-
-This function is the default for `orderless-pattern-compiler' and
-might come in handy as a subroutine to implement other pattern
-compilers."
+as the value of DISPATCHERS."
   (unless styles (setq styles orderless-matching-styles))
   (unless dispatchers (setq dispatchers orderless-style-dispatchers))
   (cl-loop
@@ -413,7 +394,7 @@ The predicate PRED is used to constrain the entries in TABLE."
     (pcase-let* ((`(,prefix . ,pattern)
                   (orderless--prefix+pattern string table pred))
                  (completion-regexp-list
-                  (funcall orderless-pattern-compiler pattern))
+                  (orderless-pattern-compiler pattern))
                  (completion-ignore-case
                   (if orderless-smart-case
                       (cl-loop for regexp in completion-regexp-list
@@ -515,7 +496,7 @@ delegates to `orderless-%s'.")
 This function is for integration of orderless with ivy, use it as
 a value in `ivy-re-builders-alist'."
   (or (mapcar (lambda (x) (cons x t))
-              (funcall orderless-pattern-compiler str))
+              (orderless-pattern-compiler str))
       ""))
 
 (defun orderless-ivy-highlight (str)

--- a/orderless.texi
+++ b/orderless.texi
@@ -14,7 +14,6 @@
 @finalout
 @titlepage
 @title Orderless
-@author Omar Antolín Camarena
 @end titlepage
 
 @contents
@@ -55,7 +54,7 @@ Related packages
 
 * Ivy and Helm::
 * Prescient::
-* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy. 
+* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy.
 
 @end detailmenu
 @end menu
@@ -131,10 +130,7 @@ define new matching styles. The predefined ones are:
 the component is treated as a regexp that must
 match somewhere in the candidate.
 
-If the component is not a valid regexp, it matches literally.
-(Having the component be invalid is actually pretty common while you
-are typing, so be prepared for the results to be a little funny
-before you close a bracket or parentheses, etc.)
+If the component is not a valid regexp, it is ignored.
 
 @item orderless-literal
 the component is treated as a literal string
@@ -294,15 +290,12 @@ completion is the one that ends up being used, of course.
 @node Pattern compiler
 @section Pattern compiler
 
-The default mechanism for turning an input string into a list of
-regexps to match against, configured using @samp{orderless-matching-styles},
-is probably flexible enough for the vast majority of users. But if you
-want to completely change the mechanism, customize the
-@samp{orderless-pattern-compiler}. It's value should be a function from
-string to lists of regexps. You might find it convenient to use
-@samp{orderless-default-pattern-compiler} as a subroutine in your own pattern
-compiler, it conveniently accepts optional arguments that specify
-lists to use instead of @samp{orderless-matching-styles}.
+The default mechanism for turning an input string into a list of regexps to
+match against, configured using @samp{orderless-matching-styles}, is probably
+flexible enough for the vast majority of users. The patterns are compiled by the
+@samp{orderless-pattern-compiler}. Under special circumstances it may be useful to
+implement a custom pattern compiler by advising the
+@samp{orderless-pattern-compiler}.
 
 @node Interactively changing the configuration
 @section Interactively changing the configuration
@@ -426,7 +419,7 @@ face with this configuration:
 @menu
 * Ivy and Helm::
 * Prescient::
-* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy. 
+* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy.
 @end menu
 
 @node Ivy and Helm
@@ -435,7 +428,7 @@ face with this configuration:
 The well-known and hugely powerful completion frameworks @uref{https://github.com/abo-abo/swiper, Ivy} and @uref{https://github.com/emacs-helm/helm, Helm}
 also provide for matching space-separated component regexps in any
 order. In Ivy, this is done with the @samp{ivy--regex-ignore-order} matcher.
-In Helm, it is the default, called ``multi pattern matching''.
+In Helm, it is the default, called "multi pattern matching".
 
 This package is significantly smaller than either of those because it
 solely defines a completion style, meant to be used with any completion UI supporting completion styles while both of those provide their own
@@ -465,7 +458,7 @@ components in any order and it can be used with either the @uref{https://github.
 or @uref{https://github.com/abo-abo/swiper, Ivy} completion UIs (it does not offer a completion-style that
 could be used with Emacs' default completion UI or with Icomplete).
 The components can be matched literally, as regexps, as initialisms or
-in the flex style (called ``fuzzy'' in prescient). In addition to
+in the flex style (called "fuzzy" in prescient). In addition to
 matching, @samp{prescient.el} also supports sorting of candidates (@samp{orderless}
 leaves that up to the candidate source and the completion UI).
 


### PR DESCRIPTION
It is unlikely that a user wants to customize this variable. If the pattern
compiler is to be replaced there is still the advice mechanism.