### PR TITLE
README: Add variable category to orderless+initialism sample

### DIFF
--- a/README.org
+++ b/README.org
@@ -245,7 +245,8 @@ completion category.
                                  orderless-regexp)))
   (setq completion-category-overrides
         '((command (styles orderless+initialism))
-          (symbol (styles orderless+initialism))))
+          (symbol (styles orderless+initialism))
+          (variable (styles orderless+initialism))))
 #+end_src
 
 Note that in order for the =orderless+initialism= style to kick-in with

--- a/orderless.texi
+++ b/orderless.texi
@@ -14,7 +14,6 @@
 @finalout
 @titlepage
 @title Orderless
-@author Omar Antolín Camarena
 @end titlepage
 
 @contents
@@ -56,7 +55,7 @@ Related packages
 
 * Ivy and Helm::
 * Prescient::
-* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy. 
+* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy.
 
 @end detailmenu
 @end menu
@@ -300,7 +299,8 @@ completion category.
                                orderless-regexp)))
 (setq completion-category-overrides
       '((command (styles orderless+initialism))
-        (symbol (styles orderless+initialism))))
+        (symbol (styles orderless+initialism))
+        (variable (styles orderless+initialism))))
 @end lisp
 
 Note that in order for the @samp{orderless+initialism} style to kick-in with
@@ -460,7 +460,7 @@ face with this configuration:
 @menu
 * Ivy and Helm::
 * Prescient::
-* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy. 
+* Restricting to current matches in Icicles, Ido and Ivy: Restricting to current matches in Icicles Ido and Ivy.
 @end menu
 
 @node Ivy and Helm
@@ -469,7 +469,7 @@ face with this configuration:
 The well-known and hugely powerful completion frameworks @uref{https://github.com/abo-abo/swiper, Ivy} and @uref{https://github.com/emacs-helm/helm, Helm}
 also provide for matching space-separated component regexps in any
 order. In Ivy, this is done with the @samp{ivy--regex-ignore-order} matcher.
-In Helm, it is the default, called ``multi pattern matching''.
+In Helm, it is the default, called "multi pattern matching".
 
 This package is significantly smaller than either of those because it
 solely defines a completion style, meant to be used with any completion UI supporting completion styles while both of those provide their own
@@ -499,7 +499,7 @@ components in any order and it can be used with either the @uref{https://github.
 or @uref{https://github.com/abo-abo/swiper, Ivy} completion UIs (it does not offer a completion-style that
 could be used with Emacs' default completion UI or with Icomplete).
 The components can be matched literally, as regexps, as initialisms or
-in the flex style (called ``fuzzy'' in prescient). In addition to
+in the flex style (called "fuzzy" in prescient). In addition to
 matching, @samp{prescient.el} also supports sorting of candidates (@samp{orderless}
 leaves that up to the candidate source and the completion UI).
 


### PR DESCRIPTION
Marginalia provides the command, symbol and variable categories.

cc @iyefrat