### PR TITLE
Use add-face-text-property

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -6,7 +6,7 @@
 ;; Keywords: extensions
 ;; Version: 0.6
 ;; Homepage: https://github.com/oantolin/orderless
-;; Package-Requires: ((emacs "24.4"))
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -278,10 +278,10 @@ at a word boundary in the candidate.  This is similar to the
            (cl-loop
             for (x y) on (or (cddr (match-data)) (match-data)) by #'cddr
             when x do
-            (font-lock-prepend-text-property
+            (add-face-text-property
              x y
-             'face (aref orderless-match-faces (mod i n))
-             string)))
+             (aref orderless-match-faces (mod i n))
+             nil string)))
   string)
 
 (defun orderless-highlight-matches (regexps strings)


### PR DESCRIPTION
`add-face-text-property` is the modern replacement of `font-lock-prepend-text-property`, which is potentially faster since it is a c function. Also updating the required Emacs version to more reasonable 26.1 as in your other packages.