### PR TITLE
README: Mention Vertico

### DIFF
--- a/README.org
+++ b/README.org
@@ -27,7 +27,7 @@ front-end that provides a completion UI. Any completion style can be
 used with the default Emacs completion UI (sometimes called minibuffer
 tab completion), with the built-in Icomplete package (which is similar
 to the more well-known Ido Mode), or with some third party completion
-frameworks such as [[https://github.com/raxod502/selectrum][Selectrum]] or [[https://github.com/oantolin/icomplete-vertical][icomplete-vertical]]. To use a
+frameworks such as [[https://github.com/raxod502/selectrum][Selectrum]], [[https://github.com/minad/vertico][Vertico]] or [[https://github.com/oantolin/icomplete-vertical][icomplete-vertical]]. To use a
 completion style in this fashion simply add it as an entry in the
 variables =completion-styles= and =completion-category-overrides= (see
 their documentation). You may also want to modify the
@@ -71,6 +71,7 @@ Bug reports are highly welcome and appreciated!
 - [[#integration-with-other-completion-uis][Integration with other completion UIs]]
   - [[#ivy][Ivy]]
   - [[#selectrum][Selectrum]]
+  - [[#vertico][Vertico]]
   - [[#company][Company]]
 - [[#related-packages][Related packages]]
   - [[#ivy-and-helm][Ivy and Helm]]
@@ -345,6 +346,12 @@ use this configuration:
 
 If you use the above configuration, only the visible candidates are
 highlighted, which is a litte more efficient.
+
+** Vertico
+
+Vertico relies on emacs built-in completion infrastructure. Hence, no
+additional configuration is necessary apart from selecting =orderless=
+as emacs default completion style.
 
 ** Company
 


### PR DESCRIPTION
Following the instructions in the readme - "If you manage to use orderless with a completion UI not listed here, please file an issue or make a pull request..." - this mentions Vertico in the Readme which also seems to become a popular choice that goes well together with orderless :-)

