### PR TITLE
Use non-greedy regex

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -198,14 +198,14 @@ sequence."
   "Match a component in flex style.
 This means the characters in COMPONENT must occur in the
 candidate in that order, but not necessarily consecutively."
-  (orderless--separated-by '(zero-or-more nonl)
+  (orderless--separated-by '(minimal-match (zero-or-more nonl))
    (cl-loop for char across component collect char)))
 
 (defun orderless-initialism (component)
   "Match a component as an initialism.
 This means the characters in COMPONENT must occur in the
 candidate, in that order, at the beginning of words."
-  (orderless--separated-by '(zero-or-more nonl)
+  (orderless--separated-by '(minimal-match (zero-or-more nonl))
    (cl-loop for char across component collect `(seq word-start ,char))))
 
 (defun orderless--strict-*-initialism (component &optional anchored)
@@ -252,7 +252,7 @@ candidate, respectively."
 The COMPONENT is split at word endings, and each piece must match
 at a word boundary in the candidate.  This is similar to the
 `partial-completion' completion style."
-  (orderless--separated-by '(zero-or-more nonl)
+  (orderless--separated-by '(minimal-match (zero-or-more nonl))
    (cl-loop for prefix in (split-string component "\\>")
             collect `(seq word-boundary ,prefix))))
 


### PR DESCRIPTION
The `orderless-flex' matching style will match input "foobr-mode" to
both "foobar-mode" and "foo-bar-baz-quux-mode", but chances are that
the user means "foobar-mode". The same is for `orderless-prefix' and
`orderless-initialism'.

By using non-greedy regexes, the shorter matches will be listed first,
which is likely what users want, rather than the longest match.