### PR TITLE
fix mis-indentification

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -186,6 +186,7 @@ This is simply `regexp-quote'.")
 If BEFORE is specified, add it to the beginning of the rx
 sequence.  If AFTER is specified, add it to the end of the rx
 sequence."
+  (declare (indent 1))
   (rx-to-string
    `(seq
      ,(or before "")
@@ -199,14 +200,14 @@ sequence."
 This means the characters in COMPONENT must occur in the
 candidate in that order, but not necessarily consecutively."
   (orderless--separated-by '(zero-or-more nonl)
-   (cl-loop for char across component collect char)))
+    (cl-loop for char across component collect char)))
 
 (defun orderless-initialism (component)
   "Match a component as an initialism.
 This means the characters in COMPONENT must occur in the
 candidate, in that order, at the beginning of words."
   (orderless--separated-by '(zero-or-more nonl)
-   (cl-loop for char across component collect `(seq word-start ,char))))
+    (cl-loop for char across component collect `(seq word-start ,char))))
 
 (defun orderless--strict-*-initialism (component &optional anchored)
   "Match a COMPONENT as a strict initialism, optionally ANCHORED.
@@ -220,11 +221,11 @@ the first word of the candidate.  If ANCHORED is `both' require
 that the first and last initials appear in the first and last
 words of the candidate, respectively."
   (orderless--separated-by
-   '(seq (zero-or-more alpha) word-end (zero-or-more (not alpha)))
-   (cl-loop for char across component collect `(seq word-start ,char))
-   (when anchored '(seq (group buffer-start) (zero-or-more (not alpha))))
-   (when (eq anchored 'both)
-     '(seq (zero-or-more alpha) word-end (zero-or-more (not alpha)) eol))))
+      '(seq (zero-or-more alpha) word-end (zero-or-more (not alpha)))
+    (cl-loop for char across component collect `(seq word-start ,char))
+    (when anchored '(seq (group buffer-start) (zero-or-more (not alpha))))
+    (when (eq anchored 'both)
+      '(seq (zero-or-more alpha) word-end (zero-or-more (not alpha)) eol))))
 
 (defun orderless-strict-initialism (component)
   "Match a COMPONENT as a strict initialism.
@@ -253,8 +254,8 @@ The COMPONENT is split at word endings, and each piece must match
 at a word boundary in the candidate.  This is similar to the
 `partial-completion' completion style."
   (orderless--separated-by '(zero-or-more nonl)
-   (cl-loop for prefix in (split-string component "\\>")
-            collect `(seq word-boundary ,prefix))))
+    (cl-loop for prefix in (split-string component "\\>")
+             collect `(seq word-boundary ,prefix))))
 
 (defun orderless-without-literal (component)
   "Match strings that do *not* contain COMPONENT as a literal match."
@@ -285,16 +286,16 @@ at a word boundary in the candidate.  This is similar to the
   string)
 
 (defun orderless-highlight-matches (regexps strings)
-    "Highlight a match of each of the REGEXPS in each of the STRINGS.
+  "Highlight a match of each of the REGEXPS in each of the STRINGS.
 Warning: only use this if you know all REGEXPs match all STRINGS!
 For the user's convenience, if REGEXPS is a string, it is
 converted to a list of regexps according to the value of
 `orderless-matching-styles'."
-    (when (stringp regexps)
-      (setq regexps (orderless-pattern-compiler regexps)))
-    (cl-loop for original in strings
-             for string = (copy-sequence original)
-             collect (orderless--highlight regexps string)))
+  (when (stringp regexps)
+    (setq regexps (orderless-pattern-compiler regexps)))
+  (cl-loop for original in strings
+           for string = (copy-sequence original)
+           collect (orderless--highlight regexps string)))
 
 ;;; Compiling patterns to lists of regexps
 
@@ -473,17 +474,17 @@ string for the completion style."
 This configures orderless according to the %s completion style and
 delegates to `orderless-%s'.")
          (fn-doc (lambda (fn) (format doc-fmt fn name name fn))))
-  `(progn
-     (defun ,try-completion (string table pred point)
-       ,(funcall fn-doc "try-completion")
-       (let ,configuration
-         (orderless-try-completion string table pred point)))
-     (defun ,all-completions (string table pred point)
-       ,(funcall fn-doc "all-completions")
-       (let ,configuration
-         (orderless-all-completions string table pred point)))
-     (add-to-list 'completion-styles-alist
-                  '(,name ,try-completion ,all-completions ,docstring)))))
+    `(progn
+       (defun ,try-completion (string table pred point)
+         ,(funcall fn-doc "try-completion")
+         (let ,configuration
+           (orderless-try-completion string table pred point)))
+       (defun ,all-completions (string table pred point)
+         ,(funcall fn-doc "all-completions")
+         (let ,configuration
+           (orderless-all-completions string table pred point)))
+       (add-to-list 'completion-styles-alist
+                    '(,name ,try-completion ,all-completions ,docstring)))))
 
 ;;; Ivy integration
 


### PR DESCRIPTION
I found some mis-indentification, I fix it.

Note: set `indent` meta option of `orderless--separated-by` `1`.
Maybe you want to keep `indent` meta option `not-set` and some
refactoring.

## under `indent` `not-set`
### before
```elisp
(defun orderless-flex (component)
  "Match a component in flex style.
This means the characters in COMPONENT must occur in the
candidate in that order, but not necessarily consecutively."
  (orderless--separated-by '(zero-or-more nonl)
                           (cl-loop for char across component collect char)))
```

### after
```elisp
(defun orderless-flex (component)
  "Match a component in flex style.
This means the characters in COMPONENT must occur in the
candidate in that order, but not necessarily consecutively."
  (let ((rxs (cl-loop for char across component collect char)))
    (orderless--separated-by '(zero-or-more nonl) rxs)))
```