### PR TITLE
Add note about custom styles for `company-capf'

### DIFF
--- a/README.org
+++ b/README.org
@@ -387,6 +387,19 @@ But there are a couple of points of discomfort:
    #+end_src
 
    (Aren't dynamically scoped variables and the advice system nifty?)
+   
+   If you would like to use different =completion-styles= with =company-capf= instead, you 
+   can add this to your config: 
+
+   #+begin_src emacs-lisp
+  ;; https://www.reddit.com/r/emacs/comments/nichkl/how_to_use_different_completion_styles_in_the/
+  (advice-add 'company-capf
+              :around
+              (lambda (capf-fn &rest args)
+                (let ((completion-styles '(basic partial-completion)))
+                  (apply capf-fn args))))
+   #+end_src
+
 
 * Related packages
 

--- a/README.org
+++ b/README.org
@@ -388,17 +388,18 @@ But there are a couple of points of discomfort:
 
    (Aren't dynamically scoped variables and the advice system nifty?)
    
-   If you would like to use different =completion-styles= with =company-capf= instead, you 
-   can add this to your config: 
+If you would like to use different =completion-styles= with =company-capf= instead, you 
+can add this to your config: 
 
-   #+begin_src emacs-lisp
-  ;; https://www.reddit.com/r/emacs/comments/nichkl/how_to_use_different_completion_styles_in_the/
-  (advice-add 'company-capf
-              :around
-              (lambda (capf-fn &rest args)
-                (let ((completion-styles '(basic partial-completion)))
-                  (apply capf-fn args))))
-   #+end_src
+#+begin_src emacs-lisp
+  ;; We follow a suggestion by company maintainer u/hvis:
+  ;; https://www.reddit.com/r/emacs/comments/nichkl/comment/gz1jr3s/
+  (defun company-completion-styles (capf-fn &rest args)
+    (let ((completion-styles '(basic partial-completion)))
+      (apply capf-fn args))
+
+  (advice-add 'company-capf :around #'company-completion-styles)
+#+end_src
 
 
 * Related packages

--- a/orderless.texi
+++ b/orderless.texi
@@ -460,6 +460,19 @@ face with this configuration:
 (Aren't dynamically scoped variables and the advice system nifty?)
 @end enumerate
 
+If you would like to use different @samp{completion-styles} with @samp{company-capf} instead, you 
+can add this to your config: 
+
+@lisp
+;; We follow a suggestion by company maintainer u/hvis:
+;; https://www.reddit.com/r/emacs/comments/nichkl/comment/gz1jr3s/
+(defun company-completion-styles (capf-fn &rest args)
+  (let ((completion-styles '(basic partial-completion)))
+    (apply capf-fn args))
+
+(advice-add 'company-capf :around #'company-completion-styles)
+@end lisp
+
 @node Related packages
 @chapter Related packages
 


### PR DESCRIPTION
I struggled with this for a while and then came across this reddit thread: https://www.reddit.com/r/emacs/comments/nichkl/how_to_use_different_completion_styles_in_the/  I think having it in the README.md will definitely help people like me in the future. 