### PR TITLE
orderless-escapable-split-on-space: Fix escaping mistake

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -305,7 +305,7 @@ converted to a list of regexps according to the value of
    (split-string (replace-regexp-in-string
                   "\\\\\\\\\\|\\\\ "
                   (lambda (x) (if (equal x "\\ ") (string 0) x))
-                  string)
+                  string 'fixedcase 'literal)
                  " +" t)))
 
 (defun orderless-dispatch (dispatchers default string &rest args)


### PR DESCRIPTION
My patch 268e56d436ef66c8d9630482cb4dae1e7ff44ee4 was not correct.