### PR TITLE
Remove strict initialism code by @noctuid

### DIFF
--- a/README.org
+++ b/README.org
@@ -144,22 +144,6 @@ define new matching styles. The predefined ones are:
 
   This maps =abc= to =\<a.*\<b.*\c=.
 
-- orderless-strict-initialism :: like initialism but only allow
-  non-letters in between the matched words.
-
-  For example =fb= would match =foo-bar= but not =foo-qux-bar=.
-
-- orderless-strict-leading-initialism :: like strict-initialism but
-  require the first initial to match the candidate's first word.
-
-  For example =bb= would match =bar-baz= but not =foo-bar-baz=.
-
-- orderless-strict-full-initialism :: like strict-initialism but
-  require the first initial to match the candidate's first word and the
-  last initial to be at the final word.
-
-  For example =fbb= would match =foo-bar-baz= but not =foo-bar-baz-qux=.
-
 - orderless-flex :: the characters of the component should appear in
   that order in the candidate, but not necessarily consecutively.
 

--- a/orderless.el
+++ b/orderless.el
@@ -128,9 +128,6 @@ a list of them."
   :options '(orderless-regexp
              orderless-literal
              orderless-initialism
-             orderless-strict-initialism
-             orderless-strict-leading-initialism
-             orderless-strict-full-initialism
              orderless-prefixes
              orderless-flex))
 
@@ -207,45 +204,6 @@ This means the characters in COMPONENT must occur in the
 candidate, in that order, at the beginning of words."
   (orderless--separated-by '(zero-or-more nonl)
    (cl-loop for char across component collect `(seq word-start ,char))))
-
-(defun orderless--strict-*-initialism (component &optional anchored)
-  "Match a COMPONENT as a strict initialism, optionally ANCHORED.
-The characters in COMPONENT must occur in the candidate in that
-order at the beginning of subsequent words comprised of letters.
-Only non-letters can be in between the words that start with the
-initials.
-
-If ANCHORED is `start' require that the first initial appear in
-the first word of the candidate.  If ANCHORED is `both' require
-that the first and last initials appear in the first and last
-words of the candidate, respectively."
-  (orderless--separated-by
-   '(seq (zero-or-more alpha) word-end (zero-or-more (not alpha)))
-   (cl-loop for char across component collect `(seq word-start ,char))
-   (when anchored '(seq (group buffer-start) (zero-or-more (not alpha))))
-   (when (eq anchored 'both)
-     '(seq (zero-or-more alpha) word-end (zero-or-more (not alpha)) eol))))
-
-(defun orderless-strict-initialism (component)
-  "Match a COMPONENT as a strict initialism.
-This means the characters in COMPONENT must occur in the
-candidate in that order at the beginning of subsequent words
-comprised of letters.  Only non-letters can be in between the
-words that start with the initials."
-  (orderless--strict-*-initialism component))
-
-(defun orderless-strict-leading-initialism (component)
-  "Match a COMPONENT as a strict initialism, anchored at start.
-See `orderless-strict-initialism'.  Additionally require that the
-first initial appear in the first word of the candidate."
-  (orderless--strict-*-initialism component 'start))
-
-(defun orderless-strict-full-initialism (component)
-  "Match a COMPONENT as a strict initialism, anchored at both ends.
-See `orderless-strict-initialism'.  Additionally require that the
-first and last initials appear in the first and last words of the
-candidate, respectively."
-  (orderless--strict-*-initialism component 'both))
 
 (defun orderless-prefixes (component)
   "Match a component as multiple word prefixes.

--- a/orderless.texi
+++ b/orderless.texi
@@ -181,25 +181,6 @@ as the beginning of a word in the candidate, in order.
 
 This maps @samp{abc} to @samp{\<a.*\<b.*\c}.
 
-@item orderless-strict-initialism
-like initialism but only allow
-non-letters in between the matched words.
-
-For example @samp{fb} would match @samp{foo-bar} but not @samp{foo-qux-bar}.
-
-@item orderless-strict-leading-initialism
-like strict-initialism but
-require the first initial to match the candidate's first word.
-
-For example @samp{bb} would match @samp{bar-baz} but not @samp{foo-bar-baz}.
-
-@item orderless-strict-full-initialism
-like strict-initialism but
-require the first initial to match the candidate's first word and the
-last initial to be at the final word.
-
-For example @samp{fbb} would match @samp{foo-bar-baz} but not @samp{foo-bar-baz-qux}.
-
 @item orderless-flex
 the characters of the component should appear in
 that order in the candidate, but not necessarily consecutively.


### PR DESCRIPTION
Omar, what do you think about the following finger excercise to fix the licensing situation in #57 to allow you to add Orderless to ELPA?

1. We remove the strict initialism code.
2. Someone with FSF assignment implements the removed functions and *promises to not look at the solution*. You should probably not do this since you already touched and refactored the relevant code.

I know it's crazy... Alternative is to just wait or add the package to NonGNU ELPA.