### PR TITLE
Fix byte compilation warning in ivy autoloads.

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -506,6 +506,7 @@ This function is for integration of orderless with ivy."
 
 ;;;###autoload
 (with-eval-after-load 'ivy
+  (defvar ivy-highlight-functions-alist)
   (add-to-list 'ivy-highlight-functions-alist
                '(orderless-ivy-re-builder . orderless-ivy-highlight)))
 


### PR DESCRIPTION
The warnings about a refrence and assignment to free variable
`ivy-highlight-function-alist' were visible with M-x
package-quickstart-refresh.