### PR TITLE
Ivy: Do not auto register the highlighting function

### DIFF
--- a/README.org
+++ b/README.org
@@ -330,6 +330,7 @@ To use =orderless= from Ivy add this to your Ivy configuration:
 
 #+begin_src emacs-lisp
   (setq ivy-re-builders-alist '((t . orderless-ivy-re-builder)))
+  (add-to-list 'ivy-highlight-functions-alist '(orderless-ivy-re-builder . orderless-ivy-highlight))
 #+end_src
 
 ** Selectrum

--- a/orderless.el
+++ b/orderless.el
@@ -504,11 +504,5 @@ a value in `ivy-re-builders-alist'."
 This function is for integration of orderless with ivy."
   (orderless--highlight (mapcar #'car ivy-regex) str) str)
 
-;;;###autoload
-(with-eval-after-load 'ivy
-  (defvar ivy-highlight-functions-alist)
-  (add-to-list 'ivy-highlight-functions-alist
-               '(orderless-ivy-re-builder . orderless-ivy-highlight)))
-
 (provide 'orderless)
 ;;; orderless.el ends here

--- a/orderless.texi
+++ b/orderless.texi
@@ -393,6 +393,7 @@ To use @samp{orderless} from Ivy add this to your Ivy configuration:
 
 @lisp
 (setq ivy-re-builders-alist '((t . orderless-ivy-re-builder)))
+(add-to-list 'ivy-highlight-functions-alist '(orderless-ivy-re-builder . orderless-ivy-highlight))
 @end lisp
 
 @node Selectrum


### PR DESCRIPTION
It seems to me that there is almost no advantage of auto loading that part of
the code in contrast to adding it to the configuration directly. Probably most
users use Orderless with completion systems like default completion, Vertico or
Mct.