### PR TITLE
Improve orderless-try-completion (Fix #118)

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -425,17 +425,18 @@ This function is part of the `orderless' completion style."
       ;; Abuse all-completions/orderless-filter as a fast search loop.
       ;; Should be almost allocation-free since our "predicate" is not
       ;; called more than two times.
-      (orderless-filter string table
-                        ;; key/value for hash tables
-                        (lambda (&rest args)
-                          (when (or (not pred) (apply pred args))
-                            (setq args (car args) ;; first argument is key
-                                  args (if (consp args) (car args) args) ;; alist
-                                  args (if (symbolp args) (symbol-name args) args))
-                            (when (and one (not (equal one args)))
-                              (throw 'orderless--many (cons string point)))
-                            (setq one args)
-                            t)))
+      (orderless-filter
+       string table
+       ;; key/value for hash tables
+       (lambda (&rest args)
+         (when (or (not pred) (apply pred args))
+           (setq args (car args) ;; first argument is key
+                 args (if (consp args) (car args) args) ;; alist
+                 args (if (symbolp args) (symbol-name args) args))
+           (when (and one (not (equal one args)))
+             (throw 'orderless--many (cons string point)))
+           (setq one args)
+           t)))
       (when one
         (if (equal string one)
             t ;; unique exact match

--- a/orderless.el
+++ b/orderless.el
@@ -423,18 +423,19 @@ This function is part of the `orderless' completion style."
   (catch 'orderless--many
     (let (one)
       ;; Abuse all-completions/orderless-filter as a fast search loop.
-      ;; Should be more or less allocation-free since our "predicate"
-      ;; always returns nil.
+      ;; Should be almost allocation-free since our "predicate" is not
+      ;; called more than two times.
       (orderless-filter string table
                         ;; key/value for hash tables
                         (lambda (&rest args)
                           (when (or (not pred) (apply pred args))
-                            (when one
+                            (setq args (car args) ;; first argument is key
+                                  args (if (consp args) (car args) args) ;; alist
+                                  args (if (symbolp args) (symbol-name args) args))
+                            (when (and one (not (equal one args)))
                               (throw 'orderless--many (cons string point)))
-                            (setq one (car args) ;; first argument is key
-                                  one (if (consp one) (car one) one) ;; alist
-                                  one (if (symbolp one) (symbol-name one) one)))
-                          nil))
+                            (setq one args)
+                            t)))
       (when one
         (if (equal string one)
             t ;; unique exact match


### PR DESCRIPTION
orderless-try-completion abuses a "predicate" which throws as a fast loop over the completion candidate.

- The predicate returns t such that all-completions returns a list (instead of nil as before). This fixes completion-table-with-predicate.

- If multiple candidates match, we check that the matches are actually different. This ensures that we don't get incorrect results if the predicate is called twice on the same candidate or if duplicates exists.

@oantolin Please check that I didn't introduce some regression.