### PR TITLE
Remove orderless-skip-highlighting

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -208,6 +208,10 @@ is determined by the values of `completion-ignore-case',
 `read-buffer-completion-ignore-case', as usual for completion."
   :type 'boolean)
 
+(defvar orderless-skip-highlighting nil)
+(make-obsolete-variable 'orderless-skip-highlighting
+                        "Use `orderless-filter' directly." "1.0")
+
 ;;; Matching styles
 
 (defun orderless-regexp (component)

--- a/orderless.el
+++ b/orderless.el
@@ -109,13 +109,6 @@ or a function of a single string argument."
   "Vector of faces used (cyclically) for component matches."
   :type '(vector face))
 
-(defcustom orderless-skip-highlighting nil
-  "Skip highlighting the matching parts of candidates?
-If this is set to a function, the function is called to decide
-whether to skip higlighting the matches.  Any non-function non-nil
-value means highlighting is skipped."
-  :type '(choice boolean function))
-
 (defcustom orderless-matching-styles
   '(orderless-literal orderless-regexp)
   "List of component matching styles.
@@ -453,16 +446,9 @@ This function is part of the `orderless' completion style."
   (let ((completions (orderless-filter string table pred)))
     (when completions
       (pcase-let ((`(,prefix . ,pattern)
-                   (orderless--prefix+pattern string table pred))
-                  (skip-highlighting
-                   (if (functionp orderless-skip-highlighting)
-                       (funcall orderless-skip-highlighting)
-                     orderless-skip-highlighting)))
-        (nconc
-         (if skip-highlighting
-             completions
-           (orderless-highlight-matches pattern completions))
-         (length prefix))))))
+                   (orderless--prefix+pattern string table pred)))
+        (nconc (orderless-highlight-matches pattern completions)
+               (length prefix))))))
 
 ;;;###autoload
 (defun orderless-try-completion (string table pred point)


### PR DESCRIPTION
This variable was added to support Selectrum, which has been deprecated now.
Vertico and Corfu use a different technique to implement deferred highlighting
for the visible candidates only.

There are no other users of this variable. The problem of deferred highlighting
must be solved more generally by improving the completion styles API itself in
minibuffer.el. It is therefore better to not provide this variable here.