### PR TITLE
orderless-affix-dispatch: Do not error on empty string

### DIFF
--- a/orderless.el
+++ b/orderless.el
@@ -160,19 +160,18 @@ If the COMPONENT starts or ends with one of the characters used
 as a key in `orderless-affix-dispatch-alist', then that character
 is removed and the remainder of the COMPONENT is matched in the
 style associated to the character."
-  (cond
-   ;; Ignore single dispatcher character
-   ((and (= (length component) 1) (alist-get (aref component 0)
-                                             orderless-affix-dispatch-alist))
-    #'ignore)
-   ;; Prefix
-   ((when-let ((style (alist-get (aref component 0)
-                                 orderless-affix-dispatch-alist)))
-      (cons style (substring component 1))))
-   ;; Suffix
-   ((when-let ((style (alist-get (aref component (1- (length component)))
-                                 orderless-affix-dispatch-alist)))
-      (cons style (substring component 0 -1))))))
+  (let ((len (length component))
+        (alist orderless-affix-dispatch-alist))
+    (when (> len 0)
+      (cond
+       ;; Ignore single dispatcher character
+       ((and (= len 1) (alist-get (aref component 0) alist)) #'ignore)
+       ;; Prefix
+       ((when-let ((style (alist-get (aref component 0) alist)))
+          (cons style (substring component 1))))
+       ;; Suffix
+       ((when-let ((style (alist-get (aref component (1- len)) alist)))
+          (cons style (substring component 0 -1))))))))
 
 (defcustom orderless-style-dispatchers (list #'orderless-affix-dispatch)
   "List of style dispatchers.


### PR DESCRIPTION
Currently the affix dispatcher errors on empty components. The error can occur if a style dispatcher returns an empty component, since then the compilation happening before style modifiers recursively calls the style dispatchers again. I am not sure if you consider this a bug? I also made the code a little bit shorter. The problem occurs with my `+orderless-keyword-dispatch` prototype, which I've posted in https://github.com/oantolin/orderless/pull/162#issuecomment-1971806583.