### PR TITLE
Two minor additions & bugfixes

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,8 +133,8 @@ matching styles are:
 - orderless-literal :: the component is treated as a literal string
   that must occur in the candidate.
 
-- orderless-prefix :: the component is treated as a literal string
-  that must occur as a prefix of a candidate.
+- orderless-literal-prefix :: the component is treated as a literal
+  string that must occur as a prefix of a candidate.
 
 - orderless-prefixes :: the component is split at word endings and
   each piece must match at a word boundary in the candidate, occurring
@@ -195,6 +195,7 @@ Style modifiers should not be used directly in
    will match against the candidate's annotation.
  - , uses =orderless-initialism=.
  - = uses =orderless-literal=.
+ - ^ uses =orderless-literal-prefix=.
  - ~ uses =orderless-flex=.
  - % makes the string match ignoring diacritics and similar
    inflections on characters (it uses the function

--- a/README.org
+++ b/README.org
@@ -133,6 +133,9 @@ matching styles are:
 - orderless-literal :: the component is treated as a literal string
   that must occur in the candidate.
 
+- orderless-prefix :: the component is treated as a literal string
+  that must occur as a prefix of a candidate.
+
 - orderless-prefixes :: the component is split at word endings and
   each piece must match at a word boundary in the candidate, occurring
   in that order.
@@ -241,7 +244,7 @@ Style modifiers should not be used directly in
    (defun not-if-bang (pattern _index _total)
      (cond
       ((equal "!" pattern)
-       '(orderless-literal . ""))
+       #'ignore)
       ((string-prefix-p "!" pattern)
        `(orderless-not . ,(substring pattern 1)))))
 

--- a/orderless.el
+++ b/orderless.el
@@ -221,6 +221,10 @@ is determined by the values of `completion-ignore-case',
   "Match COMPONENT as a literal string."
   `(literal ,component))
 
+(defun orderless-prefix (component)
+  "Match COMPONENT as a literal prefix string."
+  `(seq bol (literal ,component)))
+
 (defun orderless--separated-by (sep rxs &optional before after)
   "Return a regexp to match the rx-regexps RXS with SEP in between.
 If BEFORE is specified, add it to the beginning of the rx

--- a/orderless.el
+++ b/orderless.el
@@ -287,12 +287,14 @@ which can invert any predicate or regexp."
     (not (orderless--match-p pred regexp str))))
 
 (defun orderless--metadata ()
-  "Return completion metadata."
+  "Return completion metadata iff inside minibuffer."
   (when-let (((minibufferp))
              (table minibuffer-completion-table))
-    (completion-metadata (buffer-substring-no-properties
-                          (minibuffer-prompt-end) (point))
-                         table minibuffer-completion-predicate)))
+    ;; Return non-nil metadata iff inside minibuffer
+    (or (completion-metadata (buffer-substring-no-properties
+                              (minibuffer-prompt-end) (point))
+                             table minibuffer-completion-predicate)
+        '((nil . nil)))))
 
 (defun orderless-annotation (pred regexp)
   "Match candidates where the annotation matches PRED and REGEXP."

--- a/orderless.el
+++ b/orderless.el
@@ -286,14 +286,17 @@ which can invert any predicate or regexp."
   (lambda (str)
     (not (orderless--match-p pred regexp str))))
 
+(defun orderless--metadata ()
+  "Return completion metadata."
+  (when-let (((minibufferp))
+             (table minibuffer-completion-table))
+    (completion-metadata (buffer-substring-no-properties
+                          (minibuffer-prompt-end) (point))
+                         table minibuffer-completion-predicate)))
+
 (defun orderless-annotation (pred regexp)
   "Match candidates where the annotation matches PRED and REGEXP."
-  (when-let (((minibufferp))
-             (table minibuffer-completion-table)
-             (metadata (completion-metadata
-                        (buffer-substring-no-properties
-                         (minibuffer-prompt-end) (point))
-                        table minibuffer-completion-predicate))
+  (when-let ((metadata (orderless--metadata))
              (fun (or (completion-metadata-get
                        metadata 'annotation-function)
                       (plist-get completion-extra-properties

--- a/orderless.el
+++ b/orderless.el
@@ -223,7 +223,7 @@ is determined by the values of `completion-ignore-case',
 
 (defun orderless-prefix (component)
   "Match COMPONENT as a literal prefix string."
-  `(seq bol (literal ,component)))
+  `(seq bos (literal ,component)))
 
 (defun orderless--separated-by (sep rxs &optional before after)
   "Return a regexp to match the rx-regexps RXS with SEP in between.
@@ -493,10 +493,10 @@ The predicate PRED is used to constrain the entries in TABLE."
 ;; https://github.com/oantolin/orderless/issues/79#issuecomment-916073526
 (defun orderless--anchored-quoted-regexp (regexp)
   "Determine if REGEXP is a quoted regexp anchored at the beginning.
-If REGEXP is of the form \"\\(?:^q\\)\" for q = (regexp-quote u),
+If REGEXP is of the form \"\\(?:\\`q\\)\" for q = (regexp-quote u),
 then return (cons REGEXP u); else return nil."
-  (when (and (string-prefix-p "\\(?:^" regexp) (string-suffix-p "\\)" regexp))
-    (let ((trimmed (substring regexp 5 -2)))
+  (when (and (string-prefix-p "\\(?:\\`" regexp) (string-suffix-p "\\)" regexp))
+    (let ((trimmed (substring regexp 6 -2)))
       (unless (string-match-p "[$*+.?[\\^]"
                               (replace-regexp-in-string
                                "\\\\[$*+.?[\\^]" "" trimmed
@@ -515,7 +515,7 @@ then return (cons REGEXP u); else return nil."
 (defun orderless--filter (prefix regexps ignore-case table pred)
   "Filter TABLE by PREFIX, REGEXPS and PRED.
 The matching should be case-insensitive if IGNORE-CASE is non-nil."
-  ;; If there is a regexp of the form \(?:^quoted-regexp\) then
+  ;; If there is a regexp of the form \(?:\`quoted-regexp\) then
   ;; remove the first such and add the unquoted form to the prefix.
   (pcase (cl-loop for r in regexps
                   thereis (orderless--anchored-quoted-regexp r))

--- a/orderless.el
+++ b/orderless.el
@@ -133,6 +133,7 @@ customizing this variable to see a list of them."
     (?@ . ,#'orderless-annotation)
     (?, . ,#'orderless-initialism)
     (?= . ,#'orderless-literal)
+    (?^ . ,#'orderless-literal-prefix)
     (?~ . ,#'orderless-flex))
   "Alist associating characters to matching styles.
 The function `orderless-affix-dispatch' uses this list to
@@ -145,8 +146,9 @@ matched according the style associated to it."
           :value-type (choice
                        (const :tag "Annotation" ,#'orderless-annotation)
                        (const :tag "Literal" ,#'orderless-literal)
-                       (const :tag "Regexp" ,#'orderless-regexp)
                        (const :tag "Without literal" ,#'orderless-without-literal)
+                       (const :tag "Literal prefix" ,#'orderless-literal-prefix)
+                       (const :tag "Regexp" ,#'orderless-regexp)
                        (const :tag "Not" ,#'orderless-not)
                        (const :tag "Flex" ,#'orderless-flex)
                        (const :tag "Initialism" ,#'orderless-initialism)
@@ -221,7 +223,7 @@ is determined by the values of `completion-ignore-case',
   "Match COMPONENT as a literal string."
   `(literal ,component))
 
-(defun orderless-prefix (component)
+(defun orderless-literal-prefix (component)
   "Match COMPONENT as a literal prefix string."
   `(seq bos (literal ,component)))
 

--- a/orderless.el
+++ b/orderless.el
@@ -493,7 +493,7 @@ The predicate PRED is used to constrain the entries in TABLE."
 
 ;; Thanks to @jakanakaevangeli for writing a version of this function:
 ;; https://github.com/oantolin/orderless/issues/79#issuecomment-916073526
-(defun orderless--anchored-quoted-regexp (regexp)
+(defun orderless--literal-prefix-p (regexp)
   "Determine if REGEXP is a quoted regexp anchored at the beginning.
 If REGEXP is of the form \"\\(?:\\`q\\)\" for q = (regexp-quote u),
 then return (cons REGEXP u); else return nil."
@@ -520,7 +520,7 @@ The matching should be case-insensitive if IGNORE-CASE is non-nil."
   ;; If there is a regexp of the form \(?:\`quoted-regexp\) then
   ;; remove the first such and add the unquoted form to the prefix.
   (pcase (cl-loop for r in regexps
-                  thereis (orderless--anchored-quoted-regexp r))
+                  thereis (orderless--literal-prefix-p r))
     (`(,regexp . ,literal)
      (setq prefix (concat prefix literal)
            regexps (remove regexp regexps))))

--- a/orderless.texi
+++ b/orderless.texi
@@ -169,6 +169,10 @@ If the component is not a valid regexp, it is ignored.
 the component is treated as a literal string
 that must occur in the candidate.
 
+@item orderless-prefix
+the component is treated as a literal string
+that must occur as a prefix of a candidate.
+
 @item orderless-prefixes
 the component is split at word endings and
 each piece must match at a word boundary in the candidate, occurring
@@ -307,7 +311,7 @@ You can achieve this with the following configuration:
 (defun not-if-bang (pattern _index _total)
   (cond
    ((equal "!" pattern)
-    '(orderless-literal . ""))
+    #'ignore)
    ((string-prefix-p "!" pattern)
     `(orderless-not . ,(substring pattern 1)))))
 

--- a/orderless.texi
+++ b/orderless.texi
@@ -169,9 +169,9 @@ If the component is not a valid regexp, it is ignored.
 the component is treated as a literal string
 that must occur in the candidate.
 
-@item orderless-prefix
-the component is treated as a literal string
-that must occur as a prefix of a candidate.
+@item orderless-literal-prefix
+the component is treated as a literal
+string that must occur as a prefix of a candidate.
 
 @item orderless-prefixes
 the component is split at word endings and
@@ -253,6 +253,8 @@ will match against the candidate's annotation.
 , uses @samp{orderless-initialism}.
 @item
 = uses @samp{orderless-literal}.
+@item
+^ uses @samp{orderless-literal-prefix}.
 @item
 ~ uses @samp{orderless-flex}.
 @item


### PR DESCRIPTION
Here are two minor additions which I find useful and general enough for Orderless.

- `orderless-literal-prefix` style, which triggers the prefix filtering optimization. Can be used in custom dispatchers which treat the first component specially (the `completion-table-dynamic` scenario in Python shell completion we've talked about on Reddit) or with the affix dispatcher.

~~~ elisp
;; Custom dispatcher
(defun +orderless-prefix-dispatch (word index _total)
  "Dispatcher transforming the first WORD at INDEX=0 into a prefix regexp."
  (and (= index 0) (cons #'orderless-literal-prefix word)))

;; Register with the affix dispatcher
(setf (alist-get ?^ orderless-affix-dispatch-alist) #'orderless-literal-prefix)
~~~

- `orderless--metadata` helper function. Makes it easier to define additional matchers which rely on the completion metadata, like `+orderless-group`:

~~~ elisp
(defun +orderless-group (pred regexp)
  "Match candidate group title against PRED and REGEXP."
  (when-let ((fun (completion-metadata-get (orderless--metadata) 'group-function)))
    (lambda (str)
      (orderless--match-p pred regexp (funcall fun str nil)))))
~~~

